### PR TITLE
Add buttons under editor on page load

### DIFF
--- a/chrome/background.js
+++ b/chrome/background.js
@@ -1,0 +1,24 @@
+// background.js
+chrome.runtime.onInstalled.addListener(async () => {
+	chrome.contextMenus.create({
+		id: "encodeMenu",
+		title: "Encode",
+		type: 'normal',
+		contexts: ['all']
+	});
+	chrome.contextMenus.create({
+		id: "decodeMenu",
+		title: "Decode",
+		type: 'normal',
+		contexts: ['all']
+	});
+});
+	
+chrome.contextMenus.onClicked.addListener(menu => {
+	chrome.tabs.query({ active: true, currentWindow: true }, function(tabs) {
+		chrome.tabs.sendMessage(tabs[0].id, {
+			type: "contextMenuClicked",
+			data: menu
+		});
+	});
+});

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -15,8 +15,14 @@
 			]
 		}
 	],
+	"background": {
+		"service_worker": "background.js"
+	},
 	"action": {
 		"default_popup": "popup.html",
 		"chrome_style": true
-	}
+	},
+	"permissions": [
+		"contextMenus"
+	]
 }

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -14,5 +14,9 @@
 				"*://old.reddit.com/*"
 			]
 		}
-	]
+	],
+	"action": {
+		"default_popup": "popup.html",
+		"chrome_style": true
+	}
 }

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -7,7 +7,7 @@
 		{
 			"js": [
 				"scripts/defaultConfig.js",
-				"scripts/text-steganography.js",
+				"scripts/text-steganography-bundled.js",
 				"scripts/content.js"
 			],
 			"matches": [

--- a/chrome/popup.html
+++ b/chrome/popup.html
@@ -3,20 +3,12 @@
   <head>
   </head>
   <body>
-    <template id="li_template">
-      <li>
-        <a>
-          <h3 class="title">Tab Title</h3>
-          <p class="pathname">Tab Pathname</p>
-        </a>
-      </li>
-    </template>
 
     <h1>Argot</h1>
-    <button>Encode selected text</button>
-    <button>Decode selected text</button>
+    <button id="encodeSelectedTextButton">Encode selected text</button>
+    <button id="decodeSelectedTextButton">Decode selected text</button>
     <ul></ul>
 
-    <script src="./popup.js" type="module"></script>
+    <script src="popup.js" type="module"></script>
   </body>
 </html>

--- a/chrome/popup.html
+++ b/chrome/popup.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+  </head>
+  <body>
+    <template id="li_template">
+      <li>
+        <a>
+          <h3 class="title">Tab Title</h3>
+          <p class="pathname">Tab Pathname</p>
+        </a>
+      </li>
+    </template>
+
+    <h1>Argot</h1>
+    <button>Encode selected text</button>
+    <button>Decode selected text</button>
+    <ul></ul>
+
+    <script src="./popup.js" type="module"></script>
+  </body>
+</html>

--- a/chrome/popup.js
+++ b/chrome/popup.js
@@ -1,0 +1,11 @@
+const encodeSelectedTextButton = document.getElementById("encodeSelectedTextButton");
+encodeSelectedTextButton.addEventListener("click", () => {
+	chrome.tabs.query ({active: true, currentWindow: true}, function(tabs) {
+		chrome.tabs.sendMessage(tabs[0].id, {body: "getSelection"}, function(message) {
+			console.log("aaaaand back");
+		});
+	});
+	/*const text = getSelectedText();
+	const encodedText = TextSteganography.getEncoded(text);
+	replaceFocusedText(encodedText);*/
+});

--- a/chrome/scripts/content.js
+++ b/chrome/scripts/content.js
@@ -6,6 +6,14 @@ console.log(editorArea);
 
 const editorOriginalSubmitButton = document.querySelector(':root > body > div.content > div.commentarea > form > div.usertext-edit > div.bottom-area > div.usertext-buttons > button[type="submit"]');
 console.log(editorOriginalSubmitButton);
+const editorEncodeButton = editorOriginalSubmitButton.cloneNode(false);
+editorEncodeButton.id += 0; // TODO: Ensure unique ID.
+editorEncodeButton.textContent  = "Encode";
+editorOriginalSubmitButton.parentNode.appendChild(editorEncodeButton);
+const editorNewSubmitButton = editorOriginalSubmitButton.cloneNode(false);
+editorNewSubmitButton.id += 1; // TODO: Ensure unique ID.
+editorNewSubmitButton.textContent  = "Encode and Submit";
+editorOriginalSubmitButton.parentNode.appendChild(editorNewSubmitButton);
 
 textsToHide.forEach((currentValue, currentIndex, listObj) => {
 	currentValue.innerText = getConcealedText(defaultConfig, currentValue.innerText);

--- a/chrome/scripts/content.js
+++ b/chrome/scripts/content.js
@@ -1,3 +1,27 @@
+var clickedElement;
+
+document.addEventListener("contextmenu", function(event){
+    clickedElement = event.target;
+}, true);
+chrome.runtime.onMessage.addListener(function(message, sender, sendResponse) {
+    if (message.type === "contextMenuClicked") {
+		if (message.data.menuItemId === "encodeMenu") {
+			try {
+				clickedElement.innerText = TextSteganography.getEncodedText(defaultConfig, clickedElement.innerText);
+			} catch (error) {
+				console.log(error);
+			}
+		}
+		if (message.data.menuItemId === "decodeMenu") {
+			try {
+				clickedElement.innerText = TextSteganography.getDecodedText(defaultConfig, clickedElement.innerText);
+			} catch (error) {
+				console.log(error);
+			}
+		}
+    }
+});
+
 const textsToHide = document.querySelectorAll(':root > body > div.content div.usertext-body > div.md');
 console.log(textsToHide);
 
@@ -27,6 +51,6 @@ textsToHide.forEach((currentValue, currentIndex, listObj) => {
 	try {
 		currentValue.innerText = TextSteganography.getDecodedText(defaultConfig, currentValue.innerText);
 	} catch (error) {
-		console.error(error);
+		console.log(error);
 	}
 });

--- a/chrome/scripts/content.js
+++ b/chrome/scripts/content.js
@@ -1,6 +1,11 @@
-const textsToHide = document.querySelectorAll(":root > body > div.content div.usertext-body > div.md");
-
+const textsToHide = document.querySelectorAll(':root > body > div.content div.usertext-body > div.md');
 console.log(textsToHide);
+
+const editorArea = document.querySelector(':root > body > div.content > div.commentarea > form > div.usertext-edit > div.md > textarea');
+console.log(editorArea);
+
+const editorOriginalSubmitButton = document.querySelector(':root > body > div.content > div.commentarea > form > div.usertext-edit > div.bottom-area > div.usertext-buttons > button[type="submit"]');
+console.log(editorOriginalSubmitButton);
 
 textsToHide.forEach((currentValue, currentIndex, listObj) => {
 	currentValue.innerText = getConcealedText(defaultConfig, currentValue.innerText);

--- a/chrome/scripts/content.js
+++ b/chrome/scripts/content.js
@@ -14,7 +14,7 @@ const editorNewSubmitButton = editorOriginalSubmitButton.cloneNode(false);
 editorNewSubmitButton.id += 1; // TODO: Ensure unique ID.
 editorNewSubmitButton.textContent  = "Encode and Submit";
 editorOriginalSubmitButton.parentNode.appendChild(editorNewSubmitButton);
-
+console.log(TextSteganography);
 textsToHide.forEach((currentValue, currentIndex, listObj) => {
-	currentValue.innerText = getConcealedText(defaultConfig, currentValue.innerText);
+	currentValue.innerText = TextSteganography.getEncodedText(defaultConfig, currentValue.innerText);
 });

--- a/chrome/scripts/content.js
+++ b/chrome/scripts/content.js
@@ -3,6 +3,7 @@ var clickedElement;
 document.addEventListener("contextmenu", function(event){
     clickedElement = event.target;
 }, true);
+
 chrome.runtime.onMessage.addListener(function(message, sender, sendResponse) {
     if (message.type === "contextMenuClicked") {
 		if (message.data.menuItemId === "encodeMenu") {

--- a/chrome/scripts/content.js
+++ b/chrome/scripts/content.js
@@ -24,5 +24,9 @@ editorNewSubmitButton.textContent  = "Encode and Submit";
 editorOriginalSubmitButton.parentNode.appendChild(editorNewSubmitButton);
 
 textsToHide.forEach((currentValue, currentIndex, listObj) => {
-	currentValue.innerText = TextSteganography.getEncodedText(defaultConfig, currentValue.innerText);
+	try {
+		currentValue.innerText = TextSteganography.getDecodedText(defaultConfig, currentValue.innerText);
+	} catch (error) {
+		console.error(error);
+	}
 });

--- a/chrome/scripts/content.js
+++ b/chrome/scripts/content.js
@@ -9,12 +9,20 @@ console.log(editorOriginalSubmitButton);
 const editorEncodeButton = editorOriginalSubmitButton.cloneNode(false);
 editorEncodeButton.id += 0; // TODO: Ensure unique ID.
 editorEncodeButton.textContent  = "Encode";
+editorEncodeButton.onclick = function(){
+	editorArea.value = TextSteganography.getEncodedText(defaultConfig, editorArea.value);
+	return false;  // Return false to stop form submit.
+};
 editorOriginalSubmitButton.parentNode.appendChild(editorEncodeButton);
 const editorNewSubmitButton = editorOriginalSubmitButton.cloneNode(false);
 editorNewSubmitButton.id += 1; // TODO: Ensure unique ID.
+editorNewSubmitButton.onclick = function(){
+	editorArea.value = TextSteganography.getEncodedText(defaultConfig, editorArea.value);
+	return true;  // Return true to NOT stop form submit.
+};
 editorNewSubmitButton.textContent  = "Encode and Submit";
 editorOriginalSubmitButton.parentNode.appendChild(editorNewSubmitButton);
-console.log(TextSteganography);
+
 textsToHide.forEach((currentValue, currentIndex, listObj) => {
 	currentValue.innerText = TextSteganography.getEncodedText(defaultConfig, currentValue.innerText);
 });

--- a/chrome/scripts/defaultConfig.js
+++ b/chrome/scripts/defaultConfig.js
@@ -1,6 +1,6 @@
 const defaultConfig = {
 	debug: false,
-	password: "a",
+	password: "Argot",
 	removeNonASCII: true,
 	compressPlainText: true,
 	encrypt: true,

--- a/chrome/scripts/text-steganography.js
+++ b/chrome/scripts/text-steganography.js
@@ -1,9 +1,0 @@
-function getConcealedText(config, originalText) {
-	if (config.debug === true) return "debug";
-
-	var concealedText = originalText.slice();
-
-	var concealedText = originalText.replace(/[\u{0080}-\u{FFFF}]/gu,"");
-
-	return concealedText;
-}

--- a/common/index.js
+++ b/common/index.js
@@ -1,13 +1,23 @@
 const transformations = require('./transformations');
 
-
-module.exports = function getConcealedText(config, originalText) {
+module.exports.getEncodedText = function (config, originalText) {
 	if (config.debug === true) return "debug";
 
 	var concealedText = originalText.slice();
 
 	const transformation = transformations.createTransformation(config);
 	concealedText = transformation.getEncoded(config, originalText);
+
+	return concealedText;
+}
+
+module.exports.getDecodedText = function (config, originalText) {
+	if (config.debug === true) return "debug";
+
+	var concealedText = originalText.slice();
+
+	const transformation = transformations.createTransformation(config);
+	concealedText = transformation.getDecoded(config, originalText);
 
 	return concealedText;
 }

--- a/common/webpack.config.js
+++ b/common/webpack.config.js
@@ -8,7 +8,7 @@ const config = {
         path: __dirname,
         filename: 'text-steganography-bundled.js',
         library: {
-            name: "getConcealedText",
+            name: "TextSteganography",
             type: "var" 
         },
     },


### PR DESCRIPTION
At the very least we will need to add an "Encode" and an "Encode and Submit" button on the main text editor area.
We should also consider adding some safety mechanism that prevents submitting before encoding, although that might be annoying when someone's switching back and forth between secret and open communication.
Handling new editor areas that open up when you click "reply" on a specific comment will be handled in a separate pull request.